### PR TITLE
(BugFix) Deregistered the verify host middleware.

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const logger = require('morgan')
 const githubRouter = require('./routes/github')
 const bitbucketRouter = require('./routes/bitbucket')
 const gitlabRouter = require('./routes/gitlab')
-const verifyHostName = require('./middleware/verifyHostName')
+// const verifyHostName = require('./middleware/verifyHostName')
 
 const app = express();
 
@@ -14,7 +14,7 @@ app.use(logger('dev'))
 app.use(express.json())
 app.use(express.urlencoded({ extended: false }))
 app.use(cookieParser())
-app.use(verifyHostName())
+// TODO This middleware does not work correctly app.use(verifyHostName())
 
 app.use('/github', githubRouter)
 app.use('/bitbucket', bitbucketRouter)


### PR DESCRIPTION
* It is supposed to get the hostmane but that seems to be imposible in expressjs
* A better security methods is to be added in it's place