### PR TITLE
chore(docs): fix typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ API endpoints
 |  Path            |     Method      |   Description                     |  Parameters            |
 |:-----------------|:----------------|:----------------------------------|:-----------------------|
 |  `/api`          |       GET       |The API root                       |  None                  |
-|  `/api/regsiter` |       POST      |Create a new account               | `name,email, password` |
+|  `/api/register` |       POST      |Create a new account               | `name,email, password` |
 |  `/api/login`    |       POST      |Authenticate a user                | `email,password`       |
 |  `/api/logout`   |       POST      |End the session of the current user|  none                  |
 |  `/api/user`     |       GET       |Get the current authenticated user |  none                  |


### PR DESCRIPTION
Where it says `regsiter` it should say `register`.